### PR TITLE
Fix intermittent autoplay blocking issue by adding preload control option

### DIFF
--- a/resources/views/actions/media-modal-content.blade.php
+++ b/resources/views/actions/media-modal-content.blade.php
@@ -85,7 +85,7 @@
 
         @elseif ($mediaType === 'audio')
 
-            <audio x-ref="mediaFrame" class="rounded-lg w-full" controls @canplay="loading = false" @loadeddata="loading = false" @play="loading = false" preload="{{ $preload }}">
+            <audio x-ref="mediaFrame" class="rounded-lg w-full" controls @canplay="loading = false" @loadeddata="loading = false" @play="loading = false" {{ $preload == false ? 'preload="none"' : '' }}>
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the audio element.
             </audio>
@@ -93,7 +93,7 @@
         @elseif ($mediaType === 'video')
 
             <video x-ref="mediaFrame" class="rounded-lg" width="100%" style="aspect-ratio: 16 / 9;" controls
-                   @canplaythrough="loading = false" preload="{{ $preload }}">
+                   @canplaythrough="loading = false" {{ $preload == false ? 'preload="none"' : '' }}>
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the video tag.
             </video>

--- a/resources/views/actions/media-modal-content.blade.php
+++ b/resources/views/actions/media-modal-content.blade.php
@@ -85,7 +85,7 @@
 
         @elseif ($mediaType === 'audio')
 
-            <audio x-ref="mediaFrame" class="rounded-lg w-full" controls @canplay="loading = false" @loadeddata="loading = false" @play="loading = false">
+            <audio x-ref="mediaFrame" class="rounded-lg w-full" controls @canplay="loading = false" @loadeddata="loading = false" @play="loading = false" preload="{{ $preload }}">
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the audio element.
             </audio>
@@ -93,7 +93,7 @@
         @elseif ($mediaType === 'video')
 
             <video x-ref="mediaFrame" class="rounded-lg" width="100%" style="aspect-ratio: 16 / 9;" controls
-                   @canplaythrough="loading = false">
+                   @canplaythrough="loading = false" preload="{{ $preload }}">
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the video tag.
             </video>

--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -17,7 +17,7 @@ trait HasMedia
 
     protected bool | Closure $hasAutoplay = false;
 
-    public ?bool $isPreloading = true;
+    public ?bool $preloadAuto = true;
 
     public static function getDefaultName(): ?string
     {
@@ -132,9 +132,9 @@ trait HasMedia
         return 'unknown';
     }
 
-    public function preload(?bool $isPreloading=true): static
+    public function preload(?bool $preloadAuto=true): static
     {
-        $this->isPreloading = $isPreloading;
+        $this->preloadAuto = $preloadAuto;
 
         return $this;
     }
@@ -148,7 +148,7 @@ trait HasMedia
             'media' => $this->getMedia(),
             'mime' => $this->mime,
             'autoplay' => $this->hasAutoplay(),
-            'preload' => $this->isPreloading,
+            'preload' => $this->preloadAuto,
         ]);
     }
 

--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -17,7 +17,7 @@ trait HasMedia
 
     protected bool | Closure $hasAutoplay = false;
 
-    public ?string $preload = '';
+    public ?bool $isPreloading = true;
 
     public static function getDefaultName(): ?string
     {
@@ -132,9 +132,9 @@ trait HasMedia
         return 'unknown';
     }
 
-    public function preloadNone(): static
+    public function preload(?bool $isPreloading=true): static
     {
-        $this->preload = 'none';
+        $this->isPreloading = $isPreloading;
 
         return $this;
     }
@@ -148,7 +148,7 @@ trait HasMedia
             'media' => $this->getMedia(),
             'mime' => $this->mime,
             'autoplay' => $this->hasAutoplay(),
-            'preload' => $this->preload,
+            'preload' => $this->isPreloading,
         ]);
     }
 

--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -17,6 +17,8 @@ trait HasMedia
 
     protected bool | Closure $hasAutoplay = false;
 
+    public ?string $preload = '';
+
     public static function getDefaultName(): ?string
     {
         return 'media';
@@ -130,6 +132,13 @@ trait HasMedia
         return 'unknown';
     }
 
+    public function preloadNone(): static
+    {
+        $this->preload = 'none';
+
+        return $this;
+    }
+
     public function getContentView(): View|Htmlable
     {
         $this->mediaType = $this->detectMediaType();
@@ -139,6 +148,7 @@ trait HasMedia
             'media' => $this->getMedia(),
             'mime' => $this->mime,
             'autoplay' => $this->hasAutoplay(),
+            'preload' => $this->preload,
         ]);
     }
 


### PR DESCRIPTION
Hello, 
I tested this plugin with `autoplay()` enabled; clicking the same action sometimes refuses to play, resulting in infinite spinning. In the browser console, it can be read "Autoplay failed or was blocked". I modified the following code to get more details about the issue:

```js
mediaElement.play().catch((e) => {
    console.log(e):
    console.log('Autoplay failed or was blocked.');
});
```
Then it pointed me to https://developer.chrome.com/blog/play-request-was-interrupted.

To resume, I added a Promise to the code, but a simple preload="none" worked just fine, so I removed the Promise.

