### PR TITLE
Fix playing video on iPhone

### DIFF
--- a/resources/views/actions/media-modal-content.blade.php
+++ b/resources/views/actions/media-modal-content.blade.php
@@ -5,6 +5,7 @@
 
             init() {
                 let mediaElement = this.$refs.mediaFrame
+                mediaElement.load()
 
                 if (mediaElement && !this.autoplayed) {
                     mediaElement.onload = () => {
@@ -92,7 +93,7 @@
 
         @elseif ($mediaType === 'video')
 
-            <video x-ref="mediaFrame" class="rounded-lg" width="100%" style="aspect-ratio: 16 / 9;" controls
+            <video x-ref="mediaFrame" class="rounded-lg" width="100%" style="aspect-ratio: 16 / 9;" controls playsinline
                    @canplaythrough="loading = false" {{ $preload == false ? 'preload="none"' : '' }}>
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the video tag.


### PR DESCRIPTION
Fixes https://github.com/hugomyb/filament-media-action/issues/12

After reading a dozen articles and trying all the different solutions to this weird issue, I found out two things are necessary for this to work properly.
1. Calling `load` on the video element to trigger `canplaythrough` manually on iPhones.
2. Adding `playsinline` to prevent unwanted fullscreen video.

There were other suggestions like adding `loop autoplay muted preload="none" controls="true"` to the video element, tinkering with mimes, configuring the server for range requests, etc.

But these two changes seemed to be the only absolutely necessary ones.