### PR TITLE
Fix header case for some hosts.

### DIFF
--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -111,8 +111,11 @@ trait HasMedia
 
         // If the extension is not found, use HTTP headers to detect the content type
         $headers = @get_headers($url, 1);
-        if ($headers && isset($headers['Content-Type'])) {
-            $contentType = is_array($headers['Content-Type']) ? $headers['Content-Type'][0] : $headers['Content-Type'];
+        if($headers && is_array($headers)) {
+            $headers = array_change_key_case($headers);
+        }
+        if ($headers && isset($headers['content-type'])) {
+            $contentType = is_array($headers['content-type']) ? $headers['content-type'][0] : $headers['content-type'];
             if (strpos($contentType, 'audio') !== false) {
                 $this->mime = $contentType;
                 return 'audio';


### PR DESCRIPTION
Hi 

I developed a system that uses your plugin.
This plugin is amazing and very easy to use.

But I had a problem showing media when the URL has no extension, this problem only occurs in the production environment.

I found that the problem is with the host's web server that provides the headers in lowercase to PHP.

The web hosting that presents this problem to me is www.hostinger.com but I believe that there may be others that have a similar problem.

To avoid the problem, I ensured that the keys are always lowercase.