### PR TITLE
controlsList support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2, 8.1]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,12 +14,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2, 8.1]
-        laravel: [10.*]
+        laravel: [12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            carbon: 2.*
+          - laravel: 12.*
+            testbench: 10.*
+            carbon: 3.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.1]
+        php: [8.4, 8.3, 8.2, 8.1]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2]
         laravel: [12.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,46 @@ MediaAction::make('media-url')
     ->preload(false)
 ```
 
+#### Control list
+
+You can control the media player's interface by using the control list options. These options allow you to disable certain features of the HTML5 video and audio players.
+
+> **Note:** Control list options only work in Chromium-based browsers (Chrome, Edge, etc.) and have no effect in Firefox, Safari, or other browsers.
+
+You can use the following convenience methods:
+
+```php
+MediaAction::make('media-url')
+    ->media(fn($record) => $record->url)
+    ->disableDownload() // Prevents the user from downloading the media
+    ->disableFullscreen() // Prevents the user from viewing the video in fullscreen
+    ->disableRemotePlayback() // Prevents the user from using remote playback (e.g., Chromecast)
+```
+
+Each of these methods can accept a boolean or a closure:
+
+```php
+MediaAction::make('media-url')
+    ->media(fn($record) => $record->url)
+    ->disableDownload(fn($record) => $record->is_protected)
+```
+
+You can also set the control list directly using the `controlsList` method:
+
+```php
+MediaAction::make('media-url')
+    ->media(fn($record) => $record->url)
+    ->controlsList(['nodownload', 'nofullscreen', 'noremoteplayback'])
+```
+
+Or with a closure:
+
+```php
+MediaAction::make('media-url')
+    ->media(fn($record) => $record->url)
+    ->controlsList(fn($record) => $record->is_protected ? ['nodownload'] : [])
+```
+
 #### Other options
 
 You can customize the modal as you wish in the same way as a classic action (see https://filamentphp.com/docs/3.x/actions/modals).

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "spatie/laravel-package-tools": "^1.15.0"
+        "spatie/laravel-package-tools": "^1.92.4"
     },
     "require-dev": {
-        "nunomaduro/collision": "^7.9",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.1",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0"
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^10.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "filament/filament": "^3.0",
         "spatie/laravel-package-tools": "^1.92.4"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,8 +16,11 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="Hugomyb Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Hugomyb Unit Test Suite">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Hugomyb Feature Test Suite">
+            <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/resources/views/actions/media-modal-content.blade.php
+++ b/resources/views/actions/media-modal-content.blade.php
@@ -75,14 +75,12 @@
 
                 if (isset($parsedUrl['host'])) {
                     // Check if it's a youtu.be short URL
-                    if (strpos($parsedUrl['host'], 'youtu.be') !== false) {
-                        // Get the path and extract the video ID
+                    if (str_contains($parsedUrl['host'], 'youtu.be')) {
                         $youtubeId = ltrim($parsedUrl['path'], '/');
                     }
                     // Check if it's a regular youtube.com URL
-                    elseif (strpos($parsedUrl['host'], 'youtube.com') !== false) {
-                        // Extract the query parameters and get the 'v' parameter
-                        parse_str($parsedUrl['query'], $queryParams);
+                    elseif (str_contains($parsedUrl['host'], 'youtube.com')) {
+                        parse_str($parsedUrl['query'] ?? '', $queryParams);
                         $youtubeId = $queryParams['v'] ?? '';
                     }
                 }
@@ -93,24 +91,39 @@
                         src="https://www.youtube.com/embed/{{ $youtubeId }}{{ $autoplay ? '?autoplay=1' : '' }}"
                         frameborder="0"
                         style="aspect-ratio: 16 / 9;"
-                        allowfullscreen></iframe>
+                        allowfullscreen
+                ></iframe>
             @else
                 <p>Invalid YouTube URL.</p>
             @endif
 
         @elseif ($mediaType === 'audio')
-
-            <audio x-ref="mediaFrame" class="rounded-lg w-full" controls @canplay="loading = false"
-                   @loadeddata="loading = false"
-                   @play="loading = false" {{ $preload == false ? 'preload="none"' : '' }}>
+            <audio
+                    x-ref="mediaFrame"
+                    class="rounded-lg w-full"
+                    controls
+                    @if($controlsList) controlsList="{{ $controlsList }}" @endif
+                    @canplay="loading = false"
+                    @loadeddata="loading = false"
+                    @play="loading = false"
+                    {{ $preload ? '' : 'preload="none"' }}
+            >
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the audio element.
             </audio>
 
         @elseif ($mediaType === 'video')
-
-            <video x-ref="mediaFrame" class="rounded-lg" width="100%" style="aspect-ratio: 16 / 9;" controls playsinline
-                   @canplaythrough="loading = false" {{ $preload == false ? 'preload="none"' : '' }}>
+            <video
+                    x-ref="mediaFrame"
+                    class="rounded-lg w-full"
+                    width="100%"
+                    style="aspect-ratio: 16 / 9;"
+                    controls
+                    playsinline
+                    @if($controlsList) controlsList="{{ $controlsList }}" @endif
+                    @canplaythrough="loading = false"
+                    {{ $preload ? '' : 'preload="none"' }}
+            >
                 <source src="{{ $media }}" type="{{ $mime }}">
                 Your browser does not support the video tag.
             </video>

--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -17,6 +17,8 @@ trait HasMedia
 
     protected bool | Closure $hasAutoplay = false;
 
+    protected array | Closure $mediaControlsList = [];
+
     public ?bool $preloadAuto = true;
 
     public static function getDefaultName(): ?string
@@ -70,6 +72,67 @@ trait HasMedia
         ]);
     }
 
+    public function controlsList(array|Closure $list): static
+    {
+        $this->mediaControlsList = $list;
+
+        return $this;
+    }
+
+    public function disableDownload(bool|Closure $when = true): static
+    {
+        return $this->addMediaControlToken('nodownload', $when);
+    }
+
+    public function disableFullscreen(bool|Closure $when = true): static
+    {
+        return $this->addMediaControlToken('nofullscreen', $when);
+    }
+
+    public function disableRemotePlayback(bool|Closure $when = true): static
+    {
+        return $this->addMediaControlToken('noremoteplayback', $when);
+    }
+
+    protected function addMediaControlToken(string $token, bool|Closure $when): static
+    {
+        if ($this->evaluate($when, [
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
+        ])) {
+            $current = (array) $this->evaluate($this->mediaControlsList, [
+                ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
+                ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
+                ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
+                ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
+                ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
+            ]);
+
+            if (in_array($token, $current, true) === false) {
+                $current[] = $token;
+                $this->mediaControlsList = $current;
+            }
+        }
+
+        return $this;
+    }
+
+    protected function getMediaControlsList(): ?string
+    {
+        $list = (array) $this->evaluate($this->mediaControlsList, [
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
+            ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
+        ]);
+
+        return filled($list) ? implode(' ', $list) : null;
+    }
+
     protected function detectMediaType(): string
     {
         return $this->getMediaType($this->getMedia());
@@ -86,7 +149,7 @@ trait HasMedia
         $parsedUrl = parse_url($url, PHP_URL_PATH);
 
         // Handle cases where the URL path ends with a slash (no file)
-        if (substr($parsedUrl, -1) === '/') {
+        if (str_ends_with($parsedUrl, '/')) {
             $parsedUrl = rtrim($parsedUrl, '/');
         }
 
@@ -112,23 +175,27 @@ trait HasMedia
 
         // If the extension is not found, use HTTP headers to detect the content type
         $headers = @get_headers($url, 1);
-        if($headers && is_array($headers)) {
-            $headers = array_change_key_case($headers);
-        }
-        if ($headers && isset($headers['content-type'])) {
-            $contentType = is_array($headers['content-type']) ? $headers['content-type'][0] : $headers['content-type'];
-            if (strpos($contentType, 'audio') !== false) {
-                $this->mime = $contentType;
-                return 'audio';
-            } elseif (strpos($contentType, 'video') !== false) {
-                $this->mime = $contentType;
-                return 'video';
-            } elseif (strpos($contentType, 'image') !== false) {
-                $this->mime = $contentType;
-                return 'image';
-            } elseif (strpos($contentType, 'pdf') !== false) {
-                $this->mime = $contentType;
-                return 'pdf';
+
+        if (is_array($headers)) {
+            $headers = array_change_key_case($headers, CASE_LOWER);
+
+            $rawType = $headers['content-type'] ?? null;
+            $contentType = is_array($rawType) ? reset($rawType) : $rawType;
+
+            if ($contentType) {
+                $type = match (true) {
+                    str_contains($contentType, 'audio') => 'audio',
+                    str_contains($contentType, 'video') => 'video',
+                    str_contains($contentType, 'image') => 'image',
+                    str_contains($contentType, 'pdf') => 'pdf',
+                    default => null,
+                };
+
+                if ($type !== null) {
+                    $this->mime = $contentType;
+
+                    return $type;
+                }
             }
         }
 
@@ -153,6 +220,7 @@ trait HasMedia
             'mime' => $this->mime,
             'autoplay' => $this->hasAutoplay(),
             'preload' => $this->preloadAuto,
+            'controlsList' => $this->getMediaControlsList(),
         ]);
     }
 }

--- a/src/Concerns/HasMedia.php
+++ b/src/Concerns/HasMedia.php
@@ -98,17 +98,9 @@ trait HasMedia
     {
         if ($this->evaluate($when, [
             ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
         ])) {
             $current = (array) $this->evaluate($this->mediaControlsList, [
                 ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
-                ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
-                ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
-                ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
-                ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
             ]);
 
             if (in_array($token, $current, true) === false) {
@@ -124,10 +116,6 @@ trait HasMedia
     {
         $list = (array) $this->evaluate($this->mediaControlsList, [
             ...$this->resolveDefaultClosureDependencyForEvaluationByName('record'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('model'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('arguments'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('data'),
-            ...$this->resolveDefaultClosureDependencyForEvaluationByName('livewire'),
         ]);
 
         return filled($list) ? implode(' ', $list) : null;

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('will not use debugging functions')
-    ->expect(['dd', 'dump', 'ray'])
-    ->each->not->toBeUsed();

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can test', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Feature/MediaActionFeatureTest.php
+++ b/tests/Feature/MediaActionFeatureTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Hugomyb\FilamentMediaAction\Tests\Feature;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Actions\Action as FormAction;
+use Filament\Tables\Actions\Action as TableAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Hugomyb\FilamentMediaAction\Actions\MediaAction;
+use Hugomyb\FilamentMediaAction\Tests\Support\TestModel;
+use Hugomyb\FilamentMediaAction\Tests\Support\TestMediaAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+it('can be used as a standalone action', function () {
+    $action = MediaAction::make('view-media')
+        ->label('View Media')
+        ->media('https://example.com/video.mp4');
+
+    expect($action)->toBeInstanceOf(Action::class);
+    expect($action->getLabel())->toBe('View Media');
+});
+
+it('can detect youtube media type', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://www.youtube.com/watch?v=dQw4w9WgXcQ'))->toBe('youtube');
+    expect($testAction->getMediaType('https://youtu.be/dQw4w9WgXcQ'))->toBe('youtube');
+});
+
+it('can detect video media type', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/video.mp4'))->toBe('video');
+    expect($testAction->getMediaType('https://example.com/video.avi'))->toBe('video');
+    expect($testAction->getMediaType('https://example.com/video.mov'))->toBe('video');
+    expect($testAction->getMediaType('https://example.com/video.webm'))->toBe('video');
+});
+
+it('can detect audio media type', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/audio.mp3'))->toBe('audio');
+    expect($testAction->getMediaType('https://example.com/audio.wav'))->toBe('audio');
+    expect($testAction->getMediaType('https://example.com/audio.ogg'))->toBe('audio');
+    expect($testAction->getMediaType('https://example.com/audio.aac'))->toBe('audio');
+});
+
+it('can detect image media type', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/image.jpg'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.jpeg'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.png'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.gif'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.bmp'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.svg'))->toBe('image');
+    expect($testAction->getMediaType('https://example.com/image.webp'))->toBe('image');
+});
+
+it('can detect pdf media type', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/document.pdf'))->toBe('pdf');
+});
+
+it('can handle urls with query parameters', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/video.mp4?token=123&param=value'))->toBe('video');
+});
+
+it('returns unknown for unsupported media types', function () {
+    $testAction = new TestMediaAction('test');
+
+    expect($testAction->getMediaType('https://example.com/file.xyz'))->toBe('unknown');
+    expect($testAction->getMediaType('https://example.com/path/'))->toBe('unknown');
+});

--- a/tests/Support/TestMediaAction.php
+++ b/tests/Support/TestMediaAction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Hugomyb\FilamentMediaAction\Tests\Support;
+
+use Hugomyb\FilamentMediaAction\Actions\MediaAction;
+
+class TestMediaAction extends MediaAction
+{
+    public function getMediaType(?string $url): ?string
+    {
+        return parent::getMediaType($url);
+    }
+}

--- a/tests/Support/TestModel.php
+++ b/tests/Support/TestModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hugomyb\FilamentMediaAction\Tests\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    protected $fillable = ['name', 'media_url'];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->exists = true;
+        $this->id = 1;
+    }
+}

--- a/tests/Unit/IntegrationTest.php
+++ b/tests/Unit/IntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Filament\Actions\Action;
+use Filament\Tables\Actions\Action as TableAction;
+use Hugomyb\FilamentMediaAction\Actions\MediaAction;
+
+it('extends Filament Action class', function () {
+    expect(MediaAction::class)->toExtend(Action::class);
+});
+
+it('uses HasMedia trait', function () {
+    $traits = class_uses(MediaAction::class);
+
+    expect($traits)->toHaveKey('Hugomyb\FilamentMediaAction\Concerns\HasMedia');
+});
+
+it('has a service provider', function () {
+    $providers = config('app.providers', []);
+
+    expect(class_exists('Hugomyb\FilamentMediaAction\FilamentMediaActionServiceProvider'))->toBeTrue();
+});
+
+it('has views', function () {
+    $viewPath = __DIR__ . '/../../resources/views';
+
+    expect(is_dir($viewPath))->toBeTrue();
+    expect(file_exists($viewPath . '/actions/media-modal-content.blade.php'))->toBeTrue();
+});
+
+it('has translations', function () {
+    $langPath = __DIR__ . '/../../resources/lang';
+
+    expect(is_dir($langPath))->toBeTrue();
+});
+
+it('can be used with Filament Tables', function () {
+    $action = MediaAction::make('view-media')
+        ->label('View Media')
+        ->media('https://example.com/video.mp4');
+
+    expect(method_exists($action, 'label'))->toBeTrue();
+    expect(method_exists($action, 'icon'))->toBeTrue();
+    expect(method_exists($action, 'iconButton'))->toBeTrue();
+    expect(method_exists($action, 'modalHeading'))->toBeTrue();
+    expect(method_exists($action, 'modalDescription'))->toBeTrue();
+    expect(method_exists($action, 'modalWidth'))->toBeTrue();
+    expect(method_exists($action, 'extraModalFooterActions'))->toBeTrue();
+    expect(method_exists($action, 'media'))->toBeTrue();
+    expect(method_exists($action, 'autoplay'))->toBeTrue();
+    expect(method_exists($action, 'preload'))->toBeTrue();
+    expect(method_exists($action, 'disableDownload'))->toBeTrue();
+    expect(method_exists($action, 'disableFullscreen'))->toBeTrue();
+    expect(method_exists($action, 'disableRemotePlayback'))->toBeTrue();
+});

--- a/tests/Unit/MediaActionTest.php
+++ b/tests/Unit/MediaActionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Hugomyb\FilamentMediaAction\Actions\MediaAction;
+
+it('can be instantiated', function () {
+    $action = MediaAction::make('test');
+
+    expect($action)->toBeInstanceOf(MediaAction::class);
+});
+
+it('has the correct default name', function () {
+    expect(MediaAction::getDefaultName())->toBe('media');
+});
+
+it('can be created with a custom name', function () {
+    $action = MediaAction::make('custom-name');
+
+    expect($action->getName())->toBe('custom-name');
+});
+
+it('can be created with a label', function () {
+    $action = MediaAction::make('test')
+        ->label('Test Label');
+
+    expect($action->getLabel())->toBe('Test Label');
+});
+
+it('can be created with an icon', function () {
+    $action = MediaAction::make('test')
+        ->icon('heroicon-o-video-camera');
+
+    expect($action->getIcon())->toBe('heroicon-o-video-camera');
+});
+
+it('can be created as an icon button', function () {
+    $action = MediaAction::make('test')
+        ->iconButton();
+
+    expect($action->isIconButton())->toBeTrue();
+});
+
+it('can have a custom modal heading', function () {
+    $action = MediaAction::make('test')
+        ->modalHeading('Custom Heading');
+
+    expect($action->getModalHeading())->toBe('Custom Heading');
+});
+
+it('can have a custom modal description', function () {
+    $action = MediaAction::make('test')
+        ->modalDescription('Custom Description');
+
+    expect($action->getModalDescription())->toBe('Custom Description');
+});
+
+it('can have a custom modal width', function () {
+    $action = MediaAction::make('test')
+        ->modalWidth('xl');
+
+    expect($action->getModalWidth())->toBe('xl');
+});
+
+it('can set extra modal footer actions', function () {
+    $action = MediaAction::make('test');
+
+    expect(method_exists($action, 'extraModalFooterActions'))->toBeTrue();
+});

--- a/tests/Unit/MediaTypeDetectionTest.php
+++ b/tests/Unit/MediaTypeDetectionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Hugomyb\FilamentMediaAction\Tests\Support\TestMediaAction;
+
+it('can detect YouTube URLs', function () {
+    $action = new TestMediaAction('test');
+
+    expect($action->getMediaType('https://www.youtube.com/watch?v=dQw4w9WgXcQ'))->toBe('youtube');
+    expect($action->getMediaType('https://youtu.be/dQw4w9WgXcQ'))->toBe('youtube');
+});
+
+it('can detect video file extensions', function () {
+    $action = new TestMediaAction('test');
+    $videoExtensions = ['mp4', 'avi', 'mov', 'webm'];
+
+    foreach ($videoExtensions as $extension) {
+        expect($action->getMediaType("https://example.com/video.$extension"))->toBe('video');
+    }
+});
+
+it('can detect audio file extensions', function () {
+    $action = new TestMediaAction('test');
+    $audioExtensions = ['mp3', 'wav', 'ogg', 'aac'];
+
+    foreach ($audioExtensions as $extension) {
+        expect($action->getMediaType("https://example.com/audio.$extension"))->toBe('audio');
+    }
+});
+
+it('can detect image file extensions', function () {
+    $action = new TestMediaAction('test');
+    $imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp'];
+
+    foreach ($imageExtensions as $extension) {
+        expect($action->getMediaType("https://example.com/image.$extension"))->toBe('image');
+    }
+});
+
+it('can detect PDF file extension', function () {
+    $action = new TestMediaAction('test');
+
+    expect($action->getMediaType('https://example.com/document.pdf'))->toBe('pdf');
+});
+
+it('can handle URLs with query parameters', function () {
+    $action = new TestMediaAction('test');
+
+    expect($action->getMediaType('https://example.com/video.mp4?token=123&param=value'))->toBe('video');
+});
+
+it('returns unknown for URLs with trailing slashes', function () {
+    $action = new TestMediaAction('test');
+
+    expect($action->getMediaType('https://example.com/path/'))->toBe('unknown');
+});
+
+it('returns unknown for unsupported file extensions', function () {
+    $action = new TestMediaAction('test');
+
+    expect($action->getMediaType('https://example.com/file.xyz'))->toBe('unknown');
+});

--- a/tests/Unit/ViewRenderingTest.php
+++ b/tests/Unit/ViewRenderingTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Hugomyb\FilamentMediaAction\Actions\MediaAction;
+
+it('has a valid media modal content view file', function () {
+    $viewPath = __DIR__ . '/../../resources/views/actions/media-modal-content.blade.php';
+
+    expect(file_exists($viewPath))->toBeTrue();
+
+    $content = file_get_contents($viewPath);
+
+    expect($content)->toContain('<div class="w-full flex flex-col justify-center items-center h-full"');
+    expect($content)->toContain('@if ($mediaType === \'youtube\')');
+    expect($content)->toContain('@elseif ($mediaType === \'audio\')');
+    expect($content)->toContain('@elseif ($mediaType === \'video\')');
+    expect($content)->toContain('@elseif ($mediaType === \'image\')');
+    expect($content)->toContain('@elseif ($mediaType === \'pdf\')');
+});
+
+it('can set media url', function () {
+    $url = 'https://example.com/video.mp4';
+    $action = MediaAction::make('test')->media($url);
+
+    $reflection = new ReflectionProperty($action, 'media');
+
+    expect($reflection->getValue($action))->toBe($url);
+});
+
+it('can set autoplay option', function () {
+    $action = MediaAction::make('test')->autoplay();
+
+    $reflection = new ReflectionProperty($action, 'hasAutoplay');
+
+    expect($reflection->getValue($action))->toBeTrue();
+
+    $action->autoplay(false);
+
+    expect($reflection->getValue($action))->toBeFalse();
+});
+
+it('can set preload option', function () {
+    $action = MediaAction::make('test')->preload(false);
+
+    $reflection = new ReflectionProperty($action, 'preloadAuto');
+
+    expect($reflection->getValue($action))->toBeFalse();
+
+    $action->preload(true);
+
+    expect($reflection->getValue($action))->toBeTrue();
+});
+
+it('can see media control methods', function () {
+    $action = MediaAction::make('test');
+
+    expect(method_exists($action, 'disableDownload'))->toBeTrue();
+    expect(method_exists($action, 'disableFullscreen'))->toBeTrue();
+    expect(method_exists($action, 'disableRemotePlayback'))->toBeTrue();
+});


### PR DESCRIPTION
Hey!

This PR adds the ability to control the "controlsList" property on the HTML5 video and audio players, this property is only applicable to Chromium based browsers: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList  

I have also added test coverage for the package, dev deps updated for Laravel 12, fixed the GitHub actions and refactored some of the code. PHP 8.1 support dropped as Laravel 12 requires 8.2+